### PR TITLE
Use s3a file system for external s3 location.

### DIFF
--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/HiveMetaStoreConf.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/HiveMetaStoreConf.java
@@ -175,6 +175,11 @@ public class HiveMetaStoreConf
 
     System.out.println("Initializing configurations for warehouse: " +metaWarehouse);
 
+    conf.set("fs.s3a.access.key", System.getenv("AWS_ACCESS_KEY_ID"));
+    conf.set("fs.s3a.secret.key", System.getenv("AWS_SECRET_ACCESS_KEY"));
+    conf.set("fs.s3a.session.token", System.getenv("AWS_SESSION_TOKEN"));
+    conf.set("fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider");
+
     conf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_USER_NAME, connectionUserName);
     conf.setVar(HiveConf.ConfVars.METASTOREPWD, connectionPassword);
     conf.setVar(HiveConf.ConfVars.METASTORECONNECTURLKEY, connectionURL);

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/S3ASchemeUpdater.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/S3ASchemeUpdater.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * hms-lambda-handler
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.hms;
+
+import org.apache.hadoop.hive.metastore.api.Table;
+
+public class S3ASchemeUpdater {
+    private static final String S3_SCHEME = "s3:";
+    private static final String S3A_SCHEME = "s3a:";
+
+    public static void updateTableToUseS3AScheme(Table table) {
+        String location = table.getSd().getLocation();
+        location = S3A_SCHEME + location.substring(3);
+        table.getSd().setLocation(location);
+    }
+    public static boolean isTableUsingS3Scheme(Table table) {
+        String location = table.getSd().getLocation();
+        return location != null && location.length() >= 3 && S3_SCHEME.equals(location.substring(0, 3));
+    }
+}

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateTableHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateTableHandler.java
@@ -46,6 +46,12 @@ public class CreateTableHandler extends BaseHMSHandler<CreateTableRequest, Creat
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Table table = new Table();
       deserializer.fromString(table, request.getTableDesc());
+      /*
+      Convert s3 location to use s3a scheme in order to use S3AFileSystem.
+      1. We cannot support s3a scheme from Athena console as it enables broader audience which is not ideal.
+      2. Get table doesn't use file system and other action uses location from table storage descriptor
+         when the table was first created.
+       */
       if (S3ASchemeUpdater.isTableUsingS3Scheme(table)) {
         S3ASchemeUpdater.updateTableToUseS3AScheme(table);
       }

--- a/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateTableHandler.java
+++ b/hms-lambda-handler/src/main/java/com/amazonaws/athena/hms/handler/CreateTableHandler.java
@@ -22,6 +22,7 @@ package com.amazonaws.athena.hms.handler;
 import com.amazonaws.athena.hms.CreateTableRequest;
 import com.amazonaws.athena.hms.CreateTableResponse;
 import com.amazonaws.athena.hms.HiveMetaStoreConf;
+import com.amazonaws.athena.hms.S3ASchemeUpdater;
 import com.amazonaws.services.lambda.runtime.Context;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TDeserializer;
@@ -45,6 +46,9 @@ public class CreateTableHandler extends BaseHMSHandler<CreateTableRequest, Creat
       TDeserializer deserializer = new TDeserializer(getTProtocolFactory());
       Table table = new Table();
       deserializer.fromString(table, request.getTableDesc());
+      if (S3ASchemeUpdater.isTableUsingS3Scheme(table)) {
+        S3ASchemeUpdater.updateTableToUseS3AScheme(table);
+      }
       client.createTable(table);
       boolean successful = true;
       context.getLogger().log("Created table: " + successful);

--- a/hms-lambda-handler/src/test/java/com/amazonaws/athena/hms/TestS3ASchemeUpdater.java
+++ b/hms-lambda-handler/src/test/java/com/amazonaws/athena/hms/TestS3ASchemeUpdater.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * hms-lambda-handler
+ * %%
+ * Copyright (C) 2019 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.athena.hms;
+
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestS3ASchemeUpdater {
+    private static final String S3_LOCATION = "s3://ehms-tables/test/";
+    private static final String NON_S3_LOCATION = "sx://ehms-tables/test/";
+
+    @Test
+    public void testIsS3Scheme() {
+        Table table = buildTestTable(S3_LOCATION);
+        assertTrue(S3ASchemeUpdater.isTableUsingS3Scheme(table));
+    }
+
+    @Test
+    public void testUpdateS3Scheme() {
+        Table table = buildTestTable(S3_LOCATION);
+        S3ASchemeUpdater.updateTableToUseS3AScheme(table);
+        assertEquals("s3a://ehms-tables/test/", table.getSd().getLocation());
+    }
+
+    @Test
+    public void testIsNotS3Scheme() {
+        Table table = buildTestTable(NON_S3_LOCATION);
+        assertFalse(S3ASchemeUpdater.isTableUsingS3Scheme(table));
+    }
+
+    @Test
+    public void testIsNullLocation() {
+        Table table = buildTestTable(null);
+        assertFalse(S3ASchemeUpdater.isTableUsingS3Scheme(table));
+    }
+
+    private Table buildTestTable(String location) {
+        Table table = new Table();
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setLocation(location);
+        table.setSd(sd);
+        return table;
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* This change updates the external s3 location and update it to use s3a scheme when CTAS query is executed. This will allow hive metastore to use the most updated s3aFileSystem to access s3 location with temporary credential supported. 
* Without this conversion, hive will use deprecated S3FileSystem that doesn't support session token that doesn't meet FINRA's requirement. 
* We only convert in createTableHandler because
      1. We cannot support s3a scheme from Athena console as it enables broader audience which is not ideal.
      2. Get table doesn't use file system and other action uses location from table storage descriptor when the table was first created.
* This change should fix the issue FINRA encountered when using CTAS with external hive metastore. And this change was verified in our setup where RDS is the metastore and this lambda function is used as the connector from Athena to external metastore. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
